### PR TITLE
[fix] downgrade eks verison for prd-us-east-1 cluster

### DIFF
--- a/tf/infra/eks.tf
+++ b/tf/infra/eks.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.15.3"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.29"
+  cluster_version = "1.27"
 
   vpc_id                         = module.vpc.vpc_id
   subnet_ids                     = module.vpc.private_subnets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Downgraded EKS cluster version from 1.29 to 1.27 to ensure compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->